### PR TITLE
Fix permission issue with s2i-aspnet image

### DIFF
--- a/s2i/assemble
+++ b/s2i/assemble
@@ -27,3 +27,8 @@ cd ${HOME}
 
 dotnet restore
 dotnet build
+
+# Fix source directory permissions
+fix-permissions ./
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root


### PR DESCRIPTION
In the S2I assemble code, there is no permission fix for the directory
where the executable files are located. As a result, during the deployment
process, those files are not accessible causing permission denied error.
The deployment fails eventually afterward. The fix-permission steps are
added to apply appropreciate permission to those directories to address
the issue.

Signed-off-by: Vu Dinh vdinh@redhat.com
