### PR TITLE
Update Dockerfile to install latest dotnet SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y libunwind libicu && \
     mkdir -p ${HOME} && \
     chown -R 1001:0 ${HOME}/ && \
     chown -R 1001:0 /opt/app-root && \
-    curl -sSL -o /tmp/dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809131 && \
+    curl -sSL -o /tmp/dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=827529 && \
     mkdir -p /dotnet/ && tar zxf /tmp/dotnet.tar.gz -C /dotnet && \
     ln -s /dotnet/dotnet /usr/local/bin && \
     rm -rf /tmp/dotnet.tar.gz


### PR DESCRIPTION
This installs .NET Core 1.0.1, a patch release addressing some important issues ([notes](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-release-notes.md)).
