### PR TITLE
Use dumb-init as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ ENV \
     DOTNET_CORE_VERSION=1.0 \
     HOME=/opt/app-root/src
 
+# Install the latest 'dumb-init' release from https://github.com/Yelp/dumb-init/releases
+RUN DUMBINIT_VERSION="1.2.0" && \
+    curl -SsL https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64 > /usr/local/bin/dumb-init && \
+    chmod a+x /usr/local/bin/dumb-init
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 # Set the labels that are used for Openshift to describe the builder image.
 LABEL io.k8s.description="ASP.NET Core 1.0" \
     io.k8s.display-name="ASP.NET Core 1.0" \
@@ -34,5 +40,3 @@ USER 1001
 WORKDIR $HOME
 
 CMD ["/usr/libexec/s2i/usage"]
-
-


### PR DESCRIPTION
This PR wraps the container entrypoint with [dumb-init](https://github.com/Yelp/dumb-init). This allows proper management of external signals and zombie processes.

Without dumb-init, shell signals (such as SIGTERM) are not forwarded to the application, resulting in not being able to gracefully shutdown the application. As proof, if I run the s2i-aspnet-example application in foreground (`docker run --name testme --rm -p 8080:8080 s2i-aspnet-example`) and then in another console do a `docker stop --time=120 testme` I can see that the container takes approximately 2 minutes to stop, which means that it is not gracefully stopped. On the `docker run` console, I can see that the value of $? code is 137, which means that the container was killed with signal 9 (not graceful).

With dumb-init as ENTRYPOINT, the same tests ends up with a graceful shutdown, without having to wait 2 minutes. Container $? code is 0, successful.

Bonus: if the container is run in foreground with `-ti` argument, dumb-init will handle CTRL-C properly and gracefully shutdown the application (container $? code is 130, which means the process terminated with signal 2, upon receiving CTRL-C).
